### PR TITLE
add inline block to header list items.

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -98,6 +98,11 @@ main {
   list-style: none;
   padding: inherit;
 }
+
+.experience li {
+  display: inline-block;
+}
+
 @media screen and (min-width: 800) {
   .experience {
     flex-direction: row;


### PR DESCRIPTION
Fix issue where header rows are shown on multiple lines, even on screens big enough to accommodate the text. 